### PR TITLE
Remote flag planting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ build/
 .cache/
 .eggs/
 .tox/
+.pytest_cache/

--- a/README.md
+++ b/README.md
@@ -55,3 +55,13 @@ following command:
 This will create a zip file in your current directory containing the flags, the
 same as if you had downloaded them directly from IScorE.
 
+### Remote
+You can remotely plant flags using the `remote` subcommand. You will need to
+install the remote extras: `pip install flag-bearer[remote]`. You can then plant
+a flag with the following command:
+
+    flag-beareer remote plant -H www.team11.isucdc.com -u root -P cdc -l /root/
+
+After running this command you will be prompted just like a local plant. The
+command will attempt to verify that the flag has been planted by reading the flag
+and comparing the actual flag data.

--- a/flag_bearer/actions.py
+++ b/flag_bearer/actions.py
@@ -1,8 +1,9 @@
 from __future__ import print_function
-from six.moves import input
-import requests
-import sys
+
 import os
+import sys
+
+from six.moves import input
 
 from flag_bearer import utils
 

--- a/flag_bearer/cli.py
+++ b/flag_bearer/cli.py
@@ -34,9 +34,6 @@ try:
     remote_plant.add_argument('-p', '--port', help='The port of the remote host', default=22)
     remote_plant.add_argument('-u', '--username', help='The user to connect with')
     remote_plant.add_argument('-P', '--password', help='Password to connect with')
-    remote_plant.add_argument('-f', '--flag', help="The name of the flag to plant")
-    remote_plant.add_argument('-l', '--location', help="The location to plant the flag")
-    remote_plant.add_argument('-n', '--team', help="The team number")
 except ImportError:
     raise
     pass

--- a/flag_bearer/cli.py
+++ b/flag_bearer/cli.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from argparse import ArgumentParser
 from flag_bearer import __version__, actions, config
 
@@ -20,6 +21,25 @@ plant.add_argument('-s', '--save', action='store_true', default=False,
 
 plant = subparsers.add_parser('download', help="Download all the flags for a team")
 plant.set_defaults(func=actions.download)
+
+try:
+    import paramiko
+    from flag_bearer import remote as remote_actions
+    remote = subparsers.add_parser('remote')
+    remote_sub = remote.add_subparsers()
+
+    remote_plant = remote_sub.add_parser('plant')
+    remote_plant.set_defaults(func=remote_actions.plant)
+    remote_plant.add_argument('-H', '--host', help='The host to connect to')
+    remote_plant.add_argument('-p', '--port', help='The port of the remote host', default=22)
+    remote_plant.add_argument('-u', '--username', help='The user to connect with')
+    remote_plant.add_argument('-P', '--password', help='Password to connect with')
+    remote_plant.add_argument('-f', '--flag', help="The name of the flag to plant")
+    remote_plant.add_argument('-l', '--location', help="The location to plant the flag")
+    remote_plant.add_argument('-n', '--team', help="The team number")
+except ImportError:
+    raise
+    pass
 
 
 def main():

--- a/flag_bearer/cli.py
+++ b/flag_bearer/cli.py
@@ -25,7 +25,7 @@ plant.set_defaults(func=actions.download)
 try:
     import paramiko
     from flag_bearer import remote as remote_actions
-    remote = subparsers.add_parser('remote')
+    remote = subparsers.add_parser('remote', help='Remotely plant flags')
     remote_sub = remote.add_subparsers()
 
     remote_plant = remote_sub.add_parser('plant')
@@ -34,8 +34,8 @@ try:
     remote_plant.add_argument('-p', '--port', help='The port of the remote host', default=22)
     remote_plant.add_argument('-u', '--username', help='The user to connect with')
     remote_plant.add_argument('-P', '--password', help='Password to connect with')
+    remote_plant.add_argument('-l', '--location', help="The location to plant the flag", required=True)
 except ImportError:
-    raise
     pass
 
 

--- a/flag_bearer/config.py
+++ b/flag_bearer/config.py
@@ -7,6 +7,10 @@ ROOT = dirname(__file__)
 
 
 class Config(ConfigParser):
+    def __init__(self, *args, **kwargs):
+        super(Config, self).__init__(*args, **kwargs)
+        self.cli_args = None
+
     @classmethod
     def load(cls, noflagrc=False):
         # Load configuration files in order
@@ -30,6 +34,8 @@ class Config(ConfigParser):
         """
         Merge the configuration files with parsed arguments.
         """
+        # Keep a copy of the args for an action
+        self.cli_args = args
         if not self.has_section('iscore'):
             self.add_section('iscore')
 

--- a/flag_bearer/config.py
+++ b/flag_bearer/config.py
@@ -7,9 +7,7 @@ ROOT = dirname(__file__)
 
 
 class Config(ConfigParser):
-    def __init__(self, *args, **kwargs):
-        super(Config, self).__init__(*args, **kwargs)
-        self.cli_args = None
+    cli_args = None
 
     @classmethod
     def load(cls, noflagrc=False):

--- a/flag_bearer/remote.py
+++ b/flag_bearer/remote.py
@@ -1,10 +1,10 @@
 from __future__ import print_function
-from six import BytesIO
-from six.moves import input
-import os
+
 import sys
 
 import paramiko
+from six import BytesIO
+from six.moves import input
 
 from flag_bearer import utils
 

--- a/flag_bearer/remote.py
+++ b/flag_bearer/remote.py
@@ -86,8 +86,6 @@ def plant(conf):
 def get_file_contents(ssh, file):
     """
     Retrieve the contents of file from the remote server.
-
-    This does ***NOT*** use SFTP since teams might disallow SFTP.
     """
     _, stdout, stderr = ssh.exec_command('cat {}'.format(file))
     err = stderr.read()

--- a/flag_bearer/remote.py
+++ b/flag_bearer/remote.py
@@ -1,0 +1,85 @@
+from __future__ import print_function
+from six import BytesIO
+from six.moves import input
+import os
+import sys
+
+import paramiko
+
+from flag_bearer import utils
+
+
+def plant(conf):
+    """
+    Remotely plant a flag.
+    """
+    resp = utils.get_user(conf)
+
+    team = None
+    red = resp['profile']['is_red']
+    admin = resp['is_superuser']
+    if red or admin:
+        print("Which team do you want to get flags for?")
+        try:
+            team = int(input("> "))
+        except ValueError:
+            print("Retreiving flags for all teams")
+
+    resp = utils.get_flags(conf, team)
+    flags = {i: x for i, x in enumerate(resp)}
+
+    print("Pick the flag to place")
+    for flag_id, flag in flags.items():
+        # Admins can see both blue and red flags, tell them which is which
+        if admin:
+            print("{}. {} ({})".format(flag_id, flag['name'], flag['type']))
+        else:
+            print("{}. {}".format(flag_id, flag['name']))
+
+    flag = int(input("> "))
+
+    if flag not in flags:
+        print("[!!] Invalid selection")
+        sys.exit(1)
+
+    flag = flags[flag]
+    data = flag['data']
+
+    username = conf.cli_args.username
+    host = conf.cli_args.host
+    port = conf.cli_args.port
+    location = conf.cli_args.location
+    password = conf.cli_args.password
+
+    ssh = paramiko.SSHClient()
+    ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+    ssh.connect(host, username=username, password=password, port=port)
+
+    pkt = BytesIO()
+    pkt.write(data.encode('utf-8'))
+    pkt.write(b'\n')
+    pkt.seek(0)
+
+    sftp = ssh.open_sftp()
+    sftp.putfo(pkt, location)
+    print("Verifying flag plant")
+
+    planted_contents = get_file_contents(ssh, location)
+
+    if planted_contents != data:
+        print("Planted flag data does not match, double check the plant")
+    else:
+        print("Flag Planted")
+
+
+def get_file_contents(ssh, file):
+    """
+    Retrieve the contents of file from the remote server.
+
+    This does ***NOT*** use SFTP since teams might disallow SFTP.
+    """
+    _, stdout, stderr = ssh.exec_command('cat {}'.format(file))
+    err = stderr.read()
+    if len(err) > 0:
+        return False
+    return stdout.read().decode('utf-8').strip()

--- a/flag_bearer/utils.py
+++ b/flag_bearer/utils.py
@@ -1,3 +1,4 @@
+import difflib
 import requests
 import sys
 import zipfile
@@ -56,3 +57,8 @@ def save_flags(flags, team=None):
     for zipped_file in z.filelist:
         zipped_file.create_system = 0
     z.close()
+
+
+def get_diff(planted, actual):
+    diff = difflib.ndiff([planted], [actual])
+    return ''.join(diff)

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,12 @@ setup(
         'tox',
     ],
 
+    extras_require={
+        'remotes': [
+            'paramiko',
+        ],
+    },
+
     classifiers=[
         'Development Status :: 4 - Beta',
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,6 @@ import re
 from setuptools import setup, find_packages
 from flag_bearer import __version__
 
-
 ROOT = os.path.dirname(__file__)
 
 
@@ -23,6 +22,12 @@ def read(fname):
     return open(os.path.join(ROOT, fname)).read()
 
 
+tests_require = [
+    'vcrpy',
+    'pytest',
+    'tox',
+]
+
 setup(
     name='flag-bearer',
     version=__version__,
@@ -38,16 +43,13 @@ setup(
         'pytest-runner',
     ],
     install_requires=parse_requirements(os.path.join(ROOT, 'requirements.txt')),
-    tests_require=[
-        'vcrpy',
-        'pytest',
-        'tox',
-    ],
+    tests_require=tests_require,
 
     extras_require={
-        'remotes': [
+        'remote': [
             'paramiko',
         ],
+        'tests': tests_require,
     },
 
     classifiers=[
@@ -74,4 +76,3 @@ setup(
         'flag_bearer': ['default.ini'],
     },
 )
-

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -32,3 +32,9 @@ def test_get_flags(config):
     assert flags[0]['team_number'] == 3
     assert len(flags[0]['data']) == 50
 
+
+def test_get_diff():
+    side_a = "abc"
+    side_b = "abd"
+    diff = utils.get_diff(side_a, side_b)
+    assert diff == "- abc+ abd"


### PR DESCRIPTION
This is a port of remote flag planting from my scripts. It adds a `remote` subcommand so you can plant flags over ssh rather than doing it locally. For example:

```bash
flag-bearer remote plant -H www.team1.isucdc.com -u root -P cdc -l /root/
```
The remote subcommand is optional and only shows up when paramiko is installed. paramiko is listed in setup.py as the `remote` extra and can be installed by `pip install flag-bearer[remote]`.

Remote plant will also attempt to verify that the planted flag has the correct contents.