### PR TITLE
Add api_token to flagrc

### DIFF
--- a/flag_bearer/config.py
+++ b/flag_bearer/config.py
@@ -11,10 +11,12 @@ class Config(ConfigParser):
     def load(cls, noflagrc=False):
         # Load configuration files in order
         # - default.ini
+        # - /etc/flagrc
         # - ~/.flagrc
         conf = cls()
         conf.read(join(ROOT, 'default.ini'))
-        
+        conf.read('/etc/flagrc')
+
         # Skip loading the flagrc, only used in tests
         if noflagrc:
             return conf

--- a/flag_bearer/config.py
+++ b/flag_bearer/config.py
@@ -45,6 +45,8 @@ class Config(ConfigParser):
         self.credentials = None
         if args.api_token:
             self.api_token = args.api_token
+        elif self.has_option('iscore', 'api_token'):
+            self.api_token = self.get('iscore', 'api_token')
         else:
             print("Enter your IScorE API Token (leave blank to use your credentials)")
             self.api_token = input("> ")

--- a/flag_bearer/default.ini
+++ b/flag_bearer/default.ini
@@ -1,3 +1,5 @@
 [iscore]
 base_url=https://iscore.iseage.org
 api_version=v1
+; The api token can optionally be specified in your .flagrc
+; api_token=


### PR DESCRIPTION
An example `.flagrc`:

```ini
[iscore]
api_token=<TOKEN HERE>
```
The `--api-token` argument takes precedence over the flagrc file. The user is not prompted for a token or credentials if either of these methods is used.