### PR TITLE
Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,6 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
+  - "3.7"
 install: pip install tox-travis
 script: tox

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,7 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
 
         'Topic :: Internet :: WWW/HTTP',
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py34,py35,py36
+envlist = py27,py34,py35,py36,py37
 
 [testenv]
 deps=pytest


### PR DESCRIPTION
Add python 3.7 to the test matrix. I added this to mine the other day and realized this should probably have it as well now that travis actually supports 3.7.